### PR TITLE
ROM-9 UI Adjusments for smaller screen

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -90,6 +90,10 @@
     width: 81vw;
     height: 53vw;
   }
+
+  .extLinkButton {
+    width: 3rem
+  }
 }
 
 @media (max-width: 480px) {

--- a/client/src/components/MusicBox/AboutBox/AboutBoxStyling.js
+++ b/client/src/components/MusicBox/AboutBox/AboutBoxStyling.js
@@ -19,5 +19,8 @@ export const AboutCard = styled(Card)(({theme}) => ({
 }));
 
 export const AboutTypography = styled(Typography) ({
-    fontFamily: 'Lato'
+    fontFamily: 'Lato',
+    '@media (max-width: 768px)': {
+        fontSize: '0.75rem',
+    }
 })

--- a/client/src/components/MusicBox/ExternalLinksBox/ExtLinksBoxStyling.js
+++ b/client/src/components/MusicBox/ExternalLinksBox/ExtLinksBoxStyling.js
@@ -14,6 +14,6 @@ export const ExtLinkCard = styled(Card)(({theme}) => ({
     width: '30%',
     gap: '3rem',
     '@media (max-width: 768px)': {
-        width: '70vw',
+        width: '80vw',
     }
 }));

--- a/client/src/components/MusicBox/LyricsBox/LyricsBoxStyling.js
+++ b/client/src/components/MusicBox/LyricsBox/LyricsBoxStyling.js
@@ -20,6 +20,7 @@ export const LyricsCard = styled(Card)(({textcolor}) => ({
     alignSelf: 'center',
     '@media (max-width: 768px)': {
         width: '85vw',
+        textAlign: 'left'
     }
 }));
 
@@ -28,5 +29,9 @@ export const LyricsTitleTypography = styled(Typography)(({textcolor}) => ({
 }))
 
 export const LyricsTypography = styled(Typography)(({textcolor}) => ({
-    color: textcolor, fontFamily: 'Lato'
+    color: textcolor,
+    fontFamily: 'Lato',
+    '@media (max-width: 768px)': {
+        fontSize: '0.75rem',
+    }
 }));

--- a/client/src/components/MusicBox/MusicBoxStyling.js
+++ b/client/src/components/MusicBox/MusicBoxStyling.js
@@ -20,11 +20,12 @@ export const AboutTypography = styled(Typography)(({theme}) => ({
     color: selectTextColor(theme.palette.mode),
     padding: '1.5rem',
     fontFamily: 'Caveat',
-    fontSize: '1.3rem',
+    fontSize: '1.2rem',
     width: '60%',
     wordWrap: 'break-word',
     alignSelf: 'center',
     '@media (max-width: 768px)': {
         width: '80vw',
+        fontSize: '1rem'
     }
 }));

--- a/client/src/components/MusicBox/RadioBoxBar/RadioBoxStyling.js
+++ b/client/src/components/MusicBox/RadioBoxBar/RadioBoxStyling.js
@@ -23,5 +23,13 @@ export const RadioBoxCard = styled(Card)(({theme}) => ({
 export const ControlLabel = styled(FormControlLabel)(({show}) => ({
     opacity: show ? 1 : 0.5,
     transition: 'opacity 0.5s',
+    '@media (max-width: 768px)': {
+        '.MuiFormControlLabel-label': {
+            fontSize: '0.75rem'
+        },
+        '.MuiRadio-root': {
+            padding: '0.25rem',
+        },
+    }
 }));
 


### PR DESCRIPTION
On a smaller screen (on a phone), the radio buttons and the external link buttons don't fit in their respective boxes.